### PR TITLE
Fix HX5-D20 bringup compatibility on Humble

### DIFF
--- a/robotis_hand_bringup/launch/hx5_d20_left.launch.py
+++ b/robotis_hand_bringup/launch/hx5_d20_left.launch.py
@@ -151,9 +151,6 @@ def generate_launch_description():
         package='controller_manager',
         executable='spawner',
         arguments=[
-            '--controller-ros-args',
-            '-r /hand_l_controller/joint_trajectory:='
-            '/leader/joint_trajectory_command_broadcaster_left_hand/joint_trajectory',
             'hand_l_controller',
             'joint_state_broadcaster',
             'effort_l_controller',
@@ -161,6 +158,18 @@ def generate_launch_description():
         ],
         output='both',
         parameters=[{'robot_description': urdf_file}],
+    )
+
+    trajectory_command_relay = Node(
+        package='topic_tools',
+        executable='relay',
+        name='hand_l_joint_trajectory_relay',
+        parameters=[{
+            'input_topic':
+                '/leader/joint_trajectory_command_broadcaster_left_hand/joint_trajectory',
+            'output_topic': '/hand_l_controller/joint_trajectory',
+        }],
+        output='both',
     )
 
     robot_state_publisher_node = Node(
@@ -229,6 +238,7 @@ def generate_launch_description():
         + [
             control_node,
             robot_controller_spawner,
+            trajectory_command_relay,
             robot_state_publisher_node,
             delay_rviz_after_joint_state_broadcaster_spawner,
             delay_current_command_process_after_controllers,

--- a/robotis_hand_bringup/launch/hx5_d20_left_gazebo.launch.py
+++ b/robotis_hand_bringup/launch/hx5_d20_left_gazebo.launch.py
@@ -147,10 +147,22 @@ def generate_launch_description():
         package='controller_manager',
         executable='spawner',
         arguments=[
-            '--controller-ros-args',
-            '-r /hand_l_controller/joint_trajectory:='
-            '/leader/joint_trajectory_command_broadcaster_left_hand/joint_trajectory',
-            'hand_l_controller'],
+            'hand_l_controller',
+            '--controller-manager',
+            '/controller_manager',
+        ],
+        output='screen',
+    )
+
+    trajectory_command_relay = Node(
+        package='topic_tools',
+        executable='relay',
+        name='hand_l_joint_trajectory_relay',
+        parameters=[{
+            'input_topic':
+                '/leader/joint_trajectory_command_broadcaster_left_hand/joint_trajectory',
+            'output_topic': '/hand_l_controller/joint_trajectory',
+        }],
         output='screen',
     )
 
@@ -192,5 +204,6 @@ def generate_launch_description():
         gazebo,
         node_robot_state_publisher,
         gz_spawn_entity,
+        trajectory_command_relay,
         rviz,
     ])

--- a/robotis_hand_bringup/launch/hx5_d20_right.launch.py
+++ b/robotis_hand_bringup/launch/hx5_d20_right.launch.py
@@ -151,9 +151,6 @@ def generate_launch_description():
         package='controller_manager',
         executable='spawner',
         arguments=[
-            '--controller-ros-args',
-            '-r /hand_r_controller/joint_trajectory:='
-            '/leader/joint_trajectory_command_broadcaster_right_hand/joint_trajectory',
             'hand_r_controller',
             'joint_state_broadcaster',
             'effort_r_controller',
@@ -161,6 +158,18 @@ def generate_launch_description():
         ],
         output='both',
         parameters=[{'robot_description': urdf_file}],
+    )
+
+    trajectory_command_relay = Node(
+        package='topic_tools',
+        executable='relay',
+        name='hand_r_joint_trajectory_relay',
+        parameters=[{
+            'input_topic':
+                '/leader/joint_trajectory_command_broadcaster_right_hand/joint_trajectory',
+            'output_topic': '/hand_r_controller/joint_trajectory',
+        }],
+        output='both',
     )
 
     robot_state_publisher_node = Node(
@@ -229,6 +238,7 @@ def generate_launch_description():
         + [
             control_node,
             robot_controller_spawner,
+            trajectory_command_relay,
             robot_state_publisher_node,
             delay_rviz_after_joint_state_broadcaster_spawner,
             delay_current_command_process_after_controllers,

--- a/robotis_hand_bringup/launch/hx5_d20_right_gazebo.launch.py
+++ b/robotis_hand_bringup/launch/hx5_d20_right_gazebo.launch.py
@@ -147,10 +147,22 @@ def generate_launch_description():
         package='controller_manager',
         executable='spawner',
         arguments=[
-            '--controller-ros-args',
-            '-r /hand_r_controller/joint_trajectory:='
-            '/leader/joint_trajectory_command_broadcaster_right_hand/joint_trajectory',
-            'hand_r_controller'],
+            'hand_r_controller',
+            '--controller-manager',
+            '/controller_manager',
+        ],
+        output='screen',
+    )
+
+    trajectory_command_relay = Node(
+        package='topic_tools',
+        executable='relay',
+        name='hand_r_joint_trajectory_relay',
+        parameters=[{
+            'input_topic':
+                '/leader/joint_trajectory_command_broadcaster_right_hand/joint_trajectory',
+            'output_topic': '/hand_r_controller/joint_trajectory',
+        }],
         output='screen',
     )
 
@@ -192,5 +204,6 @@ def generate_launch_description():
         gazebo,
         node_robot_state_publisher,
         gz_spawn_entity,
+        trajectory_command_relay,
         rviz,
     ])

--- a/robotis_hand_bringup/package.xml
+++ b/robotis_hand_bringup/package.xml
@@ -16,6 +16,7 @@
   <depend>ros_gz_bridge</depend>
   <depend>ros_gz_sim</depend>
   <depend>ros_gz_image</depend>
+  <depend>topic_tools</depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>gz_ros2_control</exec_depend>
   <exec_depend>ros2_control</exec_depend>

--- a/robotis_hand_description/ros2_control/hx5_d20_rev2/hx5_d20_right.ros2_control.xacro
+++ b/robotis_hand_description/ros2_control/hx5_d20_rev2/hx5_d20_right.ros2_control.xacro
@@ -233,7 +233,7 @@
         <param name="ID">110</param>
         <param name="Reboot">1</param>
         <param name="Table Sync Enable">0</param>
-        <param name="Bus Watchdog">100</param>
+        <param name="Bus Watchdog">0</param>
         <param name="SyncTable 1 ID 1">111</param>
         <param name="SyncTable 1 ID 2">112</param>
         <param name="SyncTable 1 ID 3">113</param>
@@ -368,7 +368,7 @@
         <param name="Startup Configuration">2</param>
         <param name="Operating Mode">5</param>
         <param name="Drive Mode">13</param>
-        <param name="Bus Watchdog">100</param>
+        <param name="Bus Watchdog">0</param>
         <param name="Profile Velocity">100</param>
         <param name="Profile Acceleration">50</param>
         <param name="Position P Gain">500</param>
@@ -392,7 +392,7 @@
         <param name="Startup Configuration">2</param>
         <param name="Operating Mode">5</param>
         <param name="Drive Mode">12</param>
-        <param name="Bus Watchdog">100</param>
+        <param name="Bus Watchdog">0</param>
         <param name="Profile Velocity">100</param>
         <param name="Profile Acceleration">50</param>
         <param name="Position P Gain">500</param>
@@ -416,7 +416,7 @@
         <param name="Startup Configuration">2</param>
         <param name="Operating Mode">5</param>
         <param name="Drive Mode">12</param>
-        <param name="Bus Watchdog">100</param>
+        <param name="Bus Watchdog">0</param>
         <param name="Profile Velocity">100</param>
         <param name="Profile Acceleration">50</param>
         <param name="Position P Gain">500</param>
@@ -439,7 +439,7 @@
         <param name="Startup Configuration">2</param>
         <param name="Operating Mode">5</param>
         <param name="Drive Mode">12</param>
-        <param name="Bus Watchdog">100</param>
+        <param name="Bus Watchdog">0</param>
         <param name="Profile Velocity">100</param>
         <param name="Profile Acceleration">50</param>
         <param name="Position P Gain">500</param>
@@ -462,7 +462,7 @@
         <param name="Startup Configuration">2</param>
         <param name="Operating Mode">5</param>
         <param name="Drive Mode">12</param>
-        <param name="Bus Watchdog">100</param>
+        <param name="Bus Watchdog">0</param>
         <param name="Profile Velocity">100</param>
         <param name="Profile Acceleration">50</param>
         <param name="Position P Gain">500</param>
@@ -485,7 +485,7 @@
         <param name="Startup Configuration">2</param>
         <param name="Operating Mode">5</param>
         <param name="Drive Mode">12</param>
-        <param name="Bus Watchdog">100</param>
+        <param name="Bus Watchdog">0</param>
         <param name="Profile Velocity">100</param>
         <param name="Profile Acceleration">50</param>
         <param name="Position P Gain">500</param>
@@ -509,7 +509,7 @@
         <param name="Startup Configuration">2</param>
         <param name="Operating Mode">5</param>
         <param name="Drive Mode">12</param>
-        <param name="Bus Watchdog">100</param>
+        <param name="Bus Watchdog">0</param>
         <param name="Profile Velocity">100</param>
         <param name="Profile Acceleration">50</param>
         <param name="Position P Gain">500</param>
@@ -532,7 +532,7 @@
         <param name="Startup Configuration">2</param>
         <param name="Operating Mode">5</param>
         <param name="Drive Mode">12</param>
-        <param name="Bus Watchdog">100</param>
+        <param name="Bus Watchdog">0</param>
         <param name="Profile Velocity">100</param>
         <param name="Profile Acceleration">50</param>
         <param name="Position P Gain">500</param>
@@ -555,7 +555,7 @@
         <param name="Startup Configuration">2</param>
         <param name="Operating Mode">5</param>
         <param name="Drive Mode">12</param>
-        <param name="Bus Watchdog">100</param>
+        <param name="Bus Watchdog">0</param>
         <param name="Profile Velocity">100</param>
         <param name="Profile Acceleration">50</param>
         <param name="Position P Gain">500</param>
@@ -579,7 +579,7 @@
         <param name="Startup Configuration">2</param>
         <param name="Operating Mode">5</param>
         <param name="Drive Mode">12</param>
-        <param name="Bus Watchdog">100</param>
+        <param name="Bus Watchdog">0</param>
         <param name="Profile Velocity">100</param>
         <param name="Profile Acceleration">50</param>
         <param name="Position P Gain">500</param>
@@ -603,7 +603,7 @@
         <param name="Startup Configuration">2</param>
         <param name="Operating Mode">5</param>
         <param name="Drive Mode">12</param>
-        <param name="Bus Watchdog">100</param>
+        <param name="Bus Watchdog">0</param>
         <param name="Profile Velocity">100</param>
         <param name="Profile Acceleration">50</param>
         <param name="Position P Gain">500</param>
@@ -626,7 +626,7 @@
         <param name="Startup Configuration">2</param>
         <param name="Operating Mode">5</param>
         <param name="Drive Mode">12</param>
-        <param name="Bus Watchdog">100</param>
+        <param name="Bus Watchdog">0</param>
         <param name="Profile Velocity">100</param>
         <param name="Profile Acceleration">50</param>
         <param name="Position P Gain">500</param>
@@ -649,7 +649,7 @@
         <param name="Startup Configuration">2</param>
         <param name="Operating Mode">5</param>
         <param name="Drive Mode">12</param>
-        <param name="Bus Watchdog">100</param>
+        <param name="Bus Watchdog">0</param>
         <param name="Profile Velocity">100</param>
         <param name="Profile Acceleration">50</param>
         <param name="Position P Gain">500</param>
@@ -673,7 +673,7 @@
         <param name="Startup Configuration">2</param>
         <param name="Operating Mode">5</param>
         <param name="Drive Mode">12</param>
-        <param name="Bus Watchdog">100</param>
+        <param name="Bus Watchdog">0</param>
         <param name="Profile Velocity">100</param>
         <param name="Profile Acceleration">50</param>
         <param name="Position P Gain">500</param>
@@ -697,7 +697,7 @@
         <param name="Startup Configuration">2</param>
         <param name="Operating Mode">5</param>
         <param name="Drive Mode">12</param>
-        <param name="Bus Watchdog">100</param>
+        <param name="Bus Watchdog">0</param>
         <param name="Profile Velocity">100</param>
         <param name="Profile Acceleration">50</param>
         <param name="Position P Gain">500</param>
@@ -720,7 +720,7 @@
         <param name="Startup Configuration">2</param>
         <param name="Operating Mode">5</param>
         <param name="Drive Mode">12</param>
-        <param name="Bus Watchdog">100</param>
+        <param name="Bus Watchdog">0</param>
         <param name="Profile Velocity">100</param>
         <param name="Profile Acceleration">50</param>
         <param name="Position P Gain">500</param>
@@ -743,7 +743,7 @@
         <param name="Startup Configuration">2</param>
         <param name="Operating Mode">5</param>
         <param name="Drive Mode">12</param>
-        <param name="Bus Watchdog">100</param>
+        <param name="Bus Watchdog">0</param>
         <param name="Profile Velocity">100</param>
         <param name="Profile Acceleration">50</param>
         <param name="Position P Gain">500</param>
@@ -767,7 +767,7 @@
         <param name="Startup Configuration">2</param>
         <param name="Operating Mode">5</param>
         <param name="Drive Mode">12</param>
-        <param name="Bus Watchdog">100</param>
+        <param name="Bus Watchdog">0</param>
         <param name="Profile Velocity">100</param>
         <param name="Profile Acceleration">50</param>
         <param name="Position P Gain">500</param>
@@ -791,7 +791,7 @@
         <param name="Startup Configuration">2</param>
         <param name="Operating Mode">5</param>
         <param name="Drive Mode">12</param>
-        <param name="Bus Watchdog">100</param>
+        <param name="Bus Watchdog">0</param>
         <param name="Profile Velocity">100</param>
         <param name="Profile Acceleration">50</param>
         <param name="Position P Gain">500</param>
@@ -814,7 +814,7 @@
         <param name="Startup Configuration">2</param>
         <param name="Operating Mode">5</param>
         <param name="Drive Mode">12</param>
-        <param name="Bus Watchdog">100</param>
+        <param name="Bus Watchdog">0</param>
         <param name="Profile Velocity">100</param>
         <param name="Profile Acceleration">50</param>
         <param name="Position P Gain">500</param>

--- a/robotis_hand_description/urdf/hx5_d20_rev2/hx5_d20_right.xacro
+++ b/robotis_hand_description/urdf/hx5_d20_rev2/hx5_d20_right.xacro
@@ -4,6 +4,7 @@
   <xacro:arg name="use_sim" default="false" />
   <xacro:arg name="use_mock_hardware" default="false" />
   <xacro:arg name="mock_sensor_commands" default="false" />
+  <xacro:arg name="port_name" default="/dev/ttyUSB0" />
 
   <xacro:include filename="$(find robotis_hand_description)/urdf/hx5_d20_rev2/hx5_d20_right.urdf.xacro" />
 
@@ -25,7 +26,8 @@
   <xacro:hx5_right_system
     name="HX5RightSystem" prefix="$(arg prefix)" use_sim="$(arg use_sim)"
     use_mock_hardware="$(arg use_mock_hardware)"
-    mock_sensor_commands="$(arg mock_sensor_commands)"/>
+    mock_sensor_commands="$(arg mock_sensor_commands)"
+    port_name="$(arg port_name)"/>
 
   <gazebo>
     <plugin filename="gz_ros2_control-system" name="gz_ros2_control::GazeboSimROS2ControlPlugin">

--- a/robotis_hand_pressure_broadcaster/src/pressure_broadcaster.cpp
+++ b/robotis_hand_pressure_broadcaster/src/pressure_broadcaster.cpp
@@ -141,7 +141,7 @@ controller_interface::return_type PressureBroadcaster::update(
         return 0.0f;
       }
       return static_cast<float>(
-        state_interfaces_[base + offset].get_optional().value_or(0.0));
+        state_interfaces_[base + offset].get_value());
     };
 
     auto & sensor = message.sensors[i];


### PR DESCRIPTION
## Summary

This fixes several HX5-D20 bringup issues observed when running the current `robotis_hand` code on ROS 2 Humble with a real HX5-D20 right hand.

- Pass the `port_name` launch argument into the right-hand xacro/ros2_control path.
- Replace controller spawner remap arguments with an explicit `topic_tools` relay for Humble-compatible joint trajectory remapping.
- Add the `topic_tools` dependency.
- Use the Humble-compatible state interface value accessor in the pressure broadcaster.
- Keep the HX5-D20 right-hand Bus Watchdog initialization disabled to match the tested hardware behavior.

## Why

During hardware bringup on ROS 2 Humble, several issues prevented the hand from initializing and accepting commands reliably.

First, changing the launch argument did not actually update the ros2_control serial port. Running:

```bash
ros2 launch robotis_hand_bringup hx5_d20_right.launch.py port_name:=/dev/ttyUSB1
```

still produced hardware-interface logs using the default port:

```text
port_name /dev/ttyUSB0 / baudrate 4000000
```

The `port_name` launch argument was declared, but it was not forwarded through the right-hand xacro into the hardware system macro.

Second, the Humble controller spawner/remap path did not reliably provide the expected controller input topic. Using a `topic_tools` relay keeps the controller topic stable while still connecting the leader trajectory topic.

Third, the pressure broadcaster used the newer optional state-interface accessor, which is not compatible with the Humble API used in this workspace. `get_value()` builds and runs on the tested Humble setup.

Finally, on the tested HX5-D20 right hand, DYNAMIXEL Wizard showed the Bus Watchdog disabled on the MRT. With the launch configuration forcing watchdog values during bringup, the hand would read/sync state but command writes and torque behavior became unreliable. Keeping the watchdog disabled matched the hardware configuration and allowed command operation to recover.

## Impact

These changes make the HX5-D20 right-hand bringup usable on the tested ROS 2 Humble setup without requiring local edits to launch files or xacro files.

The serial port can now be selected through the existing `port_name:=...` launch argument, and Humble users get a working remap path for joint trajectory commands.

## Validation

Built locally on ROS 2 Humble:

```bash
colcon build --symlink-install --packages-select dynamixel_hardware_interface robotis_hand_bringup robotis_hand_description robotis_hand_pressure_broadcaster --allow-overriding dynamixel_hardware_interface
```

Validated with a real HX5-D20 right hand at 4 Mbps. DYNAMIXEL Wizard detected IDs 110-135 correctly, preset-mode motion worked, and after these bringup changes the ROS 2 launch path used the requested serial device instead of the hardcoded default.

Note: this repository currently does not expose a `humble` branch, so this PR targets `jazzy` while documenting the Humble runtime issue. Please retarget if a Humble maintenance branch is preferred.
